### PR TITLE
Maintain a common conversational history throughout a scan

### DIFF
--- a/src/ExcelWriter.py
+++ b/src/ExcelWriter.py
@@ -24,7 +24,7 @@ def write_to_excel_file(data):
     
     try:
         with tqdm(total=len(data), file=sys.stdout, desc="Writing to " + filename + ": ") as pbar:
-            workbook = xlsxwriter.Workbook(filename)
+            workbook = xlsxwriter.Workbook(filename, {'nan_inf_to_errors': True})
 
             summary = write_ai_report_worksheet(data, workbook)
             write_confusion_matrix_worksheet(summary, workbook)

--- a/src/MainProcess.py
+++ b/src/MainProcess.py
@@ -82,24 +82,26 @@ class MainProcess:
 
         # Retrieve the conversation history using the session ID
         history = get_by_session_id(self.session_id)
+        print(f"Yossi: {history=}")
 
         prompt = ChatPromptTemplate.from_messages([
             ("system",
              "You are an experienced C developer tasked with analyzing code to identify potential flaws. "
              "You understand programming language control structures. Therefore, you are capable of verifying the "
-             "call-hierarchy of a given source code. You can observe the runtime workflows."
-             "You understand the question has line numbers of the source code."
-             "The history contains previous questions and answers about the same systemd version, these answers are not necessarily correct."
-             "Your responses should be precise and no longer than two sentences. Provide justifications for your answers."
+             "call-hierarchy of a given source code. You can observe the runtime workflows. "
+             "You understand the question has line numbers of the source code. "
+             "The history contains previous questions and answers about the same systemd version, these answers are not necessarily correct. "
+             "Your responses should be precise and no longer than two sentences. Provide justifications for your answers. "
              # "Do not hallucinate. Say you don't know if you don't have this information." # LLM doesn't know it is hallucinating
              # "Answer the question using only the context"  # this line can be optional
              "First step is to see if the context has the same error stack trace. If so, it is a false positive. "
-             "For the justification you can mention that Red Hat engineers have manually verified it as false positive error."
-             "If you do not find exact error in the Context, you must perform an independent verification,"
-             "and tell us precisely if the error is a false positive or not."
-             "Answer must have following sections:"
-             "Investigation Result, Justifications, Recommendations"
-             "Structure your output into JSON format"
+             "In such a case, for the justification you can mention that Red Hat engineers have manually verified it as false positive error. "
+             "If you do not find exact error in the Context, you must perform an independent verification, "
+             "and tell us precisely if the error is a false positive or not. "
+             "Answer must have following sections: "
+             "Investigation Result, Justifications, Recommendations "
+             "Structure your output into JSON format "
+             "Use the history for reference, but do not trust it blindly. Verify the information independently. "
              "\n\nContext:{context}"
              ),
              MessagesPlaceholder(variable_name="history"),

--- a/src/run.py
+++ b/src/run.py
@@ -40,7 +40,8 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 print(" Process started! ".center(80, '-'))
 print_config()
 main_process = MainProcess(base_url=LLM_URL, llm_model_name=LLM_MODEL_NAME,
-                           embedding_llm_model_name=EMBEDDINGS_LLM_MODEL_NAME, api_key=LLM_API_KEY)
+                           embedding_llm_model_name=EMBEDDINGS_LLM_MODEL_NAME, api_key=LLM_API_KEY,
+                           session_id=REPORT_FILE_PATH.split("/")[-1].split(".html")[0])
 metric_handler = MetricHandler(main_process.get_main_llm(), main_process.get_embedding_llm())
 issue_list = read_sast_report_html(REPORT_FILE_PATH)
 summary_data = []


### PR DESCRIPTION
This is a basic implementation that saves history as is. If we want to use history in the future, we’ll need to summarize it

**Results:**
[Results of the run with context history](https://docs.google.com/spreadsheets/d/1p1M_j2bpcZgKhprPFhjPLzu1vYmRjNCH/edit?usp=sharing&ouid=111619790710498255381&rtpof=true&sd=true).
Not sure it's worth the tokens, but we do see better consistency for example in 35 and 36 - identical cases in different places. Without history (in the previous results), we got different results, but now with context, they're identical (BTW, I intentionally repeated some CVE several times)