### PR TITLE
Workaround for Json formatting errors using regex parsing

### DIFF
--- a/src/stage/filter_known_issues.py
+++ b/src/stage/filter_known_issues.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from LLMService import LLMService
 from Utils.file_utils import read_known_errors_file
@@ -25,14 +26,23 @@ def capture_known_issues(main_process: LLMService, issue_list: list, config: Con
         response = main_process.filter_known_error(false_positive_db, question, issue)
         print(f"Response of filter_known_error: {response}")
 
-        filter_response = json.loads(response)
-        print(f"{issue.id} Is known false positive? {filter_response['result']}")
-        if "yes" in filter_response['result'].strip().lower():
-            already_seen_dict[issue.id] = filter_response
+        is_valid_json = True
+        try:
+            filter_response = json.loads(response)
+            result_value = filter_response['result'].strip().lower()
+            print(f"{issue.id} Is known false positive? {result_value}")
+            is_known_false_positive = "yes" in result_value
+        except (json.JSONDecodeError, KeyError):
+            # WA: Fallback to regex check for "Result": "YES" in case the response is not valid JSON
+            # This is a temporary change to handle inconsistent response formats.
+            print(f"Response is not valid JSON. Checking for fallback condition.")
+            is_valid_json = False
+            is_known_false_positive = re.search(r'"?result"?\s*:\s*"?yes"?', response, re.IGNORECASE) is not None
+
+        if is_known_false_positive:
+            already_seen_dict[issue.id] = filter_response if is_valid_json else {"result": "YES", 
+                                                                                 "equal_error_trace": response}
             print(f"LLM found {issue.id} error trace inside known false positives list")
-            # print(issue.trace)
-            # print("Proceeding to the next issue...")
-            # continue
 
     print(f"Known false positives: {len(already_seen_dict)} / {len(issue_list)} ")
     return already_seen_dict


### PR DESCRIPTION
This depends on #13 and should be merged only after it.