### PR TITLE
Fix metrics: count positives as NOT real issues to align with false alarm detection goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ to query the vector store and review potential SAST errors.
 
 ### Evaluation
 - Applies metrics (from Ragas library) to assess the quality of model outputs.
+- **Note:** SAST-AI-Workflow is primarily focused on identifying false alarms (False Positives).
 
 ## 📊 Evaluation & Metrics
 The evaluations of the model responses are being done using the following metrics:

--- a/src/Utils/metrics_utils.py
+++ b/src/Utils/metrics_utils.py
@@ -5,6 +5,7 @@ from common.config import Config
 
 
 def count_predicted_values(data):
+    # Positives = real isse, Negatives = NOT real issue
     positives = set()
     negatives = set()
     for (issue_id, llm_response, metric_ar) in data:
@@ -15,6 +16,7 @@ def count_predicted_values(data):
     return positives, negatives
 
 def count_actual_values(data, ground_truth):
+    # Positives = real isse, Negatives = NOT real issue
     positives = set()
     negatives = set()
     
@@ -28,11 +30,18 @@ def count_actual_values(data, ground_truth):
     return positives, negatives
 
 def calculate_confusion_matrix_metrics(actual_true_positives, actual_false_positives, predicted_true_positives, predicted_false_positives):
-    tp = len(actual_true_positives & predicted_true_positives)      # Both human and AI labeled as real issue
-    tn = len(actual_false_positives & predicted_false_positives)    # Both human and AI labeled as not real issue
-    fp = len(predicted_true_positives - actual_true_positives)      # AI falsely labeled as real issue
-    fn = len(actual_true_positives - predicted_true_positives)      # AI falsely labeled as not real issue
-   
+    """
+    Note: Since our goal is to detect false alarms, positives refer to cases where issues are identified as NOT real issues.
+
+    Definitions:
+    - Negatives: Issues that are real issues.
+    - Positives: Issues that are NOT real issues (e.g., false alarms).
+    """
+    tn = len(actual_true_positives & predicted_true_positives)      # Both human and AI labeled as real issue
+    tp = len(actual_false_positives & predicted_false_positives)    # Both human and AI labeled as not real issue
+    fn = len(predicted_true_positives - actual_true_positives)      # AI falsely labeled as real issue
+    fp = len(actual_true_positives - predicted_true_positives)      # AI falsely labeled as not real issue
+
     return tp, tn, fp, fn
 
 def get_metrics(tp, tn, fp, fn):

--- a/src/Utils/metrics_utils.py
+++ b/src/Utils/metrics_utils.py
@@ -5,7 +5,8 @@ from common.config import Config
 
 
 def count_predicted_values(data):
-    # Positives = real isse, Negatives = NOT real issue
+    # Positives = real isse
+    # Negatives = NOT real issue
     positives = set()
     negatives = set()
     for (issue_id, llm_response, metric_ar) in data:
@@ -16,7 +17,8 @@ def count_predicted_values(data):
     return positives, negatives
 
 def count_actual_values(data, ground_truth):
-    # Positives = real isse, Negatives = NOT real issue
+    # Positives = real isse
+    # Negatives = NOT real issue
     positives = set()
     negatives = set()
     
@@ -34,13 +36,13 @@ def calculate_confusion_matrix_metrics(actual_true_positives, actual_false_posit
     Note: Since our goal is to detect false alarms, positives refer to cases where issues are identified as NOT real issues.
 
     Definitions:
-    - Negatives: Issues that are real issues.
     - Positives: Issues that are NOT real issues (e.g., false alarms).
+    - Negatives: Issues that are real issues.
     """
-    tn = len(actual_true_positives & predicted_true_positives)      # Both human and AI labeled as real issue
     tp = len(actual_false_positives & predicted_false_positives)    # Both human and AI labeled as not real issue
-    fn = len(predicted_true_positives - actual_true_positives)      # AI falsely labeled as real issue
+    tn = len(actual_true_positives & predicted_true_positives)      # Both human and AI labeled as real issue
     fp = len(actual_true_positives - predicted_true_positives)      # AI falsely labeled as not real issue
+    fn = len(predicted_true_positives - actual_true_positives)      # AI falsely labeled as real issue
 
     return tp, tn, fp, fn
 

--- a/src/dto/MetricRequest.py
+++ b/src/dto/MetricRequest.py
@@ -1,4 +1,4 @@
-from model.ResponseStructures import FinalJudgeResponse
+from dto.ResponseStructures import FinalJudgeResponse
 
 
 class MetricRequest:

--- a/src/dto/SummaryInfo.py
+++ b/src/dto/SummaryInfo.py
@@ -1,4 +1,4 @@
-from model.ResponseStructures import FinalJudgeResponse
+from dto.ResponseStructures import FinalJudgeResponse
 
 
 class SummaryInfo:


### PR DESCRIPTION
Fixed the metrics logic to match the following definitions:

- **Negatives:** Real issues

- **Positives:** Not real issues (i.e., **false alarms**)

This change ensures the metrics reflect our primary goal - detecting false alarms.