### PR TITLE
Ensure PR is also submitted to aiq-workflow-migration

### DIFF
--- a/.github/workflows/aiq-migration-pr-check.yml
+++ b/.github/workflows/aiq-migration-pr-check.yml
@@ -1,0 +1,39 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-feature-pr:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    
+    steps:
+      - name: Log PR info
+        run: |
+          echo "✅ Running companion‑PR check for PR #${{ github.event.pull_request.number }}"
+          echo "   • Base branch: ${{ github.event.pull_request.base.ref }}"
+          echo "   • Head branch: ${{ github.event.pull_request.head.ref }}"
+          echo "⚠️  Check may reuse logs from a previous run on same commit (diff branch)."
+          echo "If so, rerun the check after submitting PR to aiq-workflow-migration."
+
+      - name: Check for matching AIQ PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr      = context.payload.pull_request;
+            console.log(`🔍 Looking for companion PR into 'aiq-workflow-migration' from '${pr.head.ref}'`);
+            const { data: companions } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              base: "aiq-workflow-migration",
+              head: `${context.repo.owner}:${pr.head.ref}`,
+            });
+            console.log(`   • Found ${companions.length} companion PR(s)`);
+            if (!companions.length) {
+              core.setFailed(`❌ No companion PR into 'aiq-workflow-migration' from branch '${pr.head.ref}'.`);
+            } else {
+              console.log(`✅ Companion PR #${companions[0].number} found: ${companions[0].html_url}`);
+            }


### PR DESCRIPTION
Add a validation step to confirm that any PR is also opened in the aiq-workflow-migration repository during the transition to NeMo. Ensuring that `aiq-workflow-migration` stays up to date with changes from `main`.