### PR TITLE
Appeng 3379 implement calculate metrics node

### DIFF
--- a/src/sast_agent_workflow/tools/calculate_metrics.py
+++ b/src/sast_agent_workflow/tools/calculate_metrics.py
@@ -8,14 +8,14 @@ from aiq.cli.register_workflow import register_function
 from aiq.data_models.function import FunctionBaseConfig
 
 from dto.SASTWorkflowModels import SASTWorkflowTracker
+from dto.EvaluationSummary import EvaluationSummary
+from dto.SummaryInfo import SummaryInfo
+from Utils.file_utils import get_human_verified_results
 
 logger = logging.getLogger(__name__)
 
 
 class CalculateMetricsConfig(FunctionBaseConfig, name="calculate_metrics"):
-    """
-    Calculate metrics function for SAST workflow.
-    """
     description: str = Field(
         default="Calculate metrics function that calculates performance metrics for SAST analysis",
         description="Function description"
@@ -26,18 +26,39 @@ class CalculateMetricsConfig(FunctionBaseConfig, name="calculate_metrics"):
 async def calculate_metrics(
     config: CalculateMetricsConfig, builder: Builder
 ):
-    """Register the Calculate_Metrics function."""
-    
     logger.info("Initializing Calculate_Metrics function...")
     
     async def _calculate_metrics_fn(tracker: SASTWorkflowTracker) -> SASTWorkflowTracker:
-        """
-        Calculate metrics function for SAST workflow.
-        """
         logger.info("Running Calculate_Metrics node - calculating metrics")
         logger.info(f"Calculate_Metrics node processing tracker with {len(tracker.issues)} issues")
         
-        # TODO: Implement actual metrics calculation logic here
+        if not tracker.config:
+            logger.warning("No config found in tracker - skipping metrics calculation")
+            return tracker
+            
+        if not tracker.config.CALCULATE_METRICS:
+            logger.info("CALCULATE_METRICS is disabled in config - skipping metrics calculation")
+            return tracker
+        
+        try:
+            summary_data = _convert_tracker_to_summary_data(tracker)
+            
+            if not summary_data:
+                logger.warning("No completed issues found for metrics calculation")
+                tracker.metrics = {"error": "No completed issues found"}
+                return tracker
+            
+            ground_truth = get_human_verified_results(tracker.config)
+            
+            evaluation_summary = EvaluationSummary(summary_data, tracker.config, ground_truth)
+            
+            tracker.metrics = _extract_metrics_from_evaluation_summary(evaluation_summary)
+            
+            logger.info(f"Successfully calculated metrics for {len(summary_data)} issues")
+            
+        except Exception as e:
+            logger.error(f"Failed to calculate metrics: {e}")
+            tracker.metrics = {"error": f"Metrics calculation failed: {str(e)}"}
         
         logger.info("Calculate_Metrics node completed")
         return tracker
@@ -52,3 +73,62 @@ async def calculate_metrics(
         logger.info("Calculate_Metrics function exited early!")
     finally:
         logger.info("Cleaning up Calculate_Metrics function.")
+
+
+def _convert_tracker_to_summary_data(tracker: SASTWorkflowTracker) -> list:
+    summary_data = []
+    
+    for issue_id, per_issue_data in tracker.issues.items():
+        if (per_issue_data.analysis_response and 
+            per_issue_data.analysis_response.is_final == "TRUE"):
+            
+            summary_info = SummaryInfo(
+                response=per_issue_data.analysis_response,
+                metrics={},
+                critique_response=per_issue_data.analysis_response,
+                context=""
+            )
+            
+            summary_data.append((per_issue_data.issue, summary_info))
+    
+    return summary_data
+
+
+def _extract_metrics_from_evaluation_summary(evaluation_summary: EvaluationSummary) -> dict:
+    excluded_attrs = {'summary_data', 'config', 'ground_truth', 'predicted_summary', 'predicted_true_positives', 'predicted_false_positives', 'actual_true_positives', 'actual_false_positives', 'tp', 'tn', 'fp', 'fn'}
+    
+    metrics = {
+        "total_issues": len(evaluation_summary.predicted_summary),
+        "predicted_true_positives_count": len(evaluation_summary.predicted_true_positives),
+        "predicted_false_positives_count": len(evaluation_summary.predicted_false_positives),
+        "has_ground_truth": evaluation_summary.ground_truth is not None
+    }
+    
+    if evaluation_summary.ground_truth is None:
+        logger.info("No ground truth data available - calculating basic statistics only")
+        _add_dynamic_metrics(evaluation_summary, metrics, excluded_attrs, None)
+        metrics["confusion_matrix"] = None
+    else:
+        logger.info("Ground truth available - calculating full performance metrics")
+        metrics.update({
+            "actual_true_positives_count": len(evaluation_summary.actual_true_positives),
+            "actual_false_positives_count": len(evaluation_summary.actual_false_positives),
+            "confusion_matrix": {
+                "true_positives": evaluation_summary.tp,
+                "true_negatives": evaluation_summary.tn,
+                "false_positives": evaluation_summary.fp,
+                "false_negatives": evaluation_summary.fn
+            }
+        })
+        _add_dynamic_metrics(evaluation_summary, metrics, excluded_attrs, None)
+    
+    return metrics
+
+
+def _add_dynamic_metrics(evaluation_summary: EvaluationSummary, metrics: dict, excluded_attrs: set, default_value):
+    for attr_name in dir(evaluation_summary):
+        if not attr_name.startswith('_') and attr_name not in excluded_attrs:
+            if hasattr(evaluation_summary, attr_name):
+                attr_value = getattr(evaluation_summary, attr_name)
+                if not callable(attr_value):
+                    metrics[attr_name] = default_value if default_value is not None else attr_value

--- a/tests/aiq_tests/test_calculate_metrics.py
+++ b/tests/aiq_tests/test_calculate_metrics.py
@@ -1,71 +1,283 @@
-"""
-Unit tests for the calculate_metrics tool's core function.
-"""
-
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from sast_agent_workflow.tools.calculate_metrics import calculate_metrics, CalculateMetricsConfig
-from dto.SASTWorkflowModels import SASTWorkflowTracker
+from dto.SASTWorkflowModels import SASTWorkflowTracker, PerIssueData
 from dto.Issue import Issue
-from dto.LLMResponse import AnalysisResponse
+from dto.LLMResponse import AnalysisResponse, CVEValidationStatus
 from common.config import Config
 from aiq.builder.builder import Builder
 from tests.aiq_tests.test_utils import TestUtils
 
 
 class TestCalculateMetricsCore(unittest.IsolatedAsyncioTestCase):
-    """Test cases for the calculate_metrics core function (_calculate_metrics_fn)."""
 
     def setUp(self):
-        """Set up test fixtures."""
         self.sample_issues = TestUtils.create_sample_issues()
-        self.mock_config = Mock(spec=Config)
         self.calculate_metrics_config = CalculateMetricsConfig()
         self.builder = Mock(spec=Builder)
-        
-        # Create a sample tracker with issues
-        self.sample_tracker = TestUtils.create_sample_tracker(self.sample_issues)
 
-    async def test_given_sample_tracker_when_calculate_metrics_executed_then_preserves_tracker_structure_and_updates_metrics(self):
-        """Given a sample tracker, when calculate_metrics is executed, then it preserves tracker structure and updates metrics.
-            
-           Expected state changes for Calculate_Metrics tool:
-           - global metrics dictionary should be populated with ragas metrics
-           - Only runs if metrics calculation is enabled in config
-           - All other tracker fields should remain unchanged
-           - Iteration count should remain unchanged
-           
-           TODO: Add comprehensive tests after tool implementation including:
-           - ragas metrics calculation logic tests
-           - Config-based enable/disable tests
-           - Error handling tests (calculation failures)
-        """
+    def _create_mock_config(self, calculate_metrics=True, use_critique_as_final=False):
+        mock_config = Mock(spec=Config)
+        mock_config.CALCULATE_METRICS = calculate_metrics
+        mock_config.USE_CRITIQUE_AS_FINAL_RESULTS = use_critique_as_final
+        return mock_config
+
+    async def test__aiq_tests__calculate_metrics_disabled_preserves_empty_metrics(self):
         # preparation
-        # TODO: Mock the actual metrics calculation dependencies when implemented
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=False)
         
         # testing
-        result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, self.sample_tracker)
+        with self.assertLogs('sast_agent_workflow.tools.calculate_metrics', level='INFO') as log:
+            result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
         
         # assertion
-        self.assertIsInstance(result_tracker, SASTWorkflowTracker)
-        
+        self.assertEqual(result_tracker.metrics, {})
         self.assertEqual(len(result_tracker.issues), 2)
-        self.assertEqual(result_tracker.iteration_count, 0)
-        self.assertEqual(result_tracker.config, self.sample_tracker.config)
+        self.assertTrue(any("CALCULATE_METRICS is disabled" in record.message for record in log.records))
+
+    async def test__aiq_tests__no_config_preserves_empty_metrics(self):
+        # preparation
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = None
         
-        for per_issue_data in result_tracker.issues.values():
-            self.assertIsNotNone(per_issue_data.issue)
+        # testing
+        with self.assertLogs('sast_agent_workflow.tools.calculate_metrics', level='WARNING') as log:
+            result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        self.assertEqual(result_tracker.metrics, {})
+        self.assertTrue(any("No config found" in record.message for record in log.records))
+
+    async def test__aiq_tests__no_completed_issues_returns_error(self):
+        # preparation
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=True)
+        for per_issue_data in tracker.issues.values():
+            per_issue_data.analysis_response.is_final = "FALSE"
+        
+        # testing
+        result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        self.assertIn("error", result_tracker.metrics)
+        self.assertEqual(result_tracker.metrics["error"], "No completed issues found")
+        self.assertEqual(len(result_tracker.metrics), 1)
+
+    async def test__aiq_tests__mixed_issues_processes_only_final(self):
+        # preparation
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=True)
+        
+        issue_ids = list(tracker.issues.keys())
+        tracker.issues[issue_ids[0]].analysis_response.is_final = "TRUE"
+        tracker.issues[issue_ids[0]].analysis_response.investigation_result = CVEValidationStatus.TRUE_POSITIVE.value
+        tracker.issues[issue_ids[1]].analysis_response.is_final = "FALSE"
+        
+        # testing
+        with patch('sast_agent_workflow.tools.calculate_metrics.get_human_verified_results') as mock_get_ground_truth:
+            mock_get_ground_truth.return_value = None
+            result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        metrics = result_tracker.metrics
+        self.assertEqual(metrics["total_issues"], 1)
+        self.assertEqual(metrics["predicted_true_positives_count"], 1)
+        self.assertEqual(metrics["predicted_false_positives_count"], 0)
+
+    @patch('sast_agent_workflow.tools.calculate_metrics.get_human_verified_results')
+    async def test__aiq_tests__no_ground_truth_calculates_basic_metrics(self, mock_get_ground_truth):
+        # preparation
+        mock_get_ground_truth.return_value = None
+        
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=True)
+        
+        issue_ids = list(tracker.issues.keys())
+        tracker.issues[issue_ids[0]].analysis_response.investigation_result = CVEValidationStatus.TRUE_POSITIVE.value
+        tracker.issues[issue_ids[0]].analysis_response.is_final = "TRUE"
+        tracker.issues[issue_ids[1]].analysis_response.investigation_result = CVEValidationStatus.FALSE_POSITIVE.value
+        tracker.issues[issue_ids[1]].analysis_response.is_final = "TRUE"
+        
+        # testing
+        result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        expected_metrics = {
+            "total_issues": 2,
+            "predicted_true_positives_count": 1,
+            "predicted_false_positives_count": 1,
+            "has_ground_truth": False,
+            "accuracy": None,
+            "precision": None,
+            "recall": None,
+            "f1_score": None,
+            "confusion_matrix": None
+        }
+        self.assertEqual(result_tracker.metrics, expected_metrics)
+        mock_get_ground_truth.assert_called_once_with(tracker.config)
+
+    @patch('sast_agent_workflow.tools.calculate_metrics.get_human_verified_results')
+    async def test__aiq_tests__with_ground_truth_calculates_full_metrics(self, mock_get_ground_truth):
+        # preparation
+        mock_ground_truth = {
+            "def1": "yes",
+            "def2": "no"
+        }
+        mock_get_ground_truth.return_value = mock_ground_truth
+        
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=True)
+        
+        issue_ids = list(tracker.issues.keys())
+        tracker.issues[issue_ids[0]].analysis_response.investigation_result = CVEValidationStatus.FALSE_POSITIVE.value
+        tracker.issues[issue_ids[0]].analysis_response.is_final = "TRUE"
+        tracker.issues[issue_ids[1]].analysis_response.investigation_result = CVEValidationStatus.FALSE_POSITIVE.value
+        tracker.issues[issue_ids[1]].analysis_response.is_final = "TRUE"
+        
+        # testing
+        result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        metrics = result_tracker.metrics
+        self.assertEqual(metrics["total_issues"], 2)
+        self.assertEqual(metrics["has_ground_truth"], True)
+        self.assertEqual(metrics["actual_true_positives_count"], 1)
+        self.assertEqual(metrics["actual_false_positives_count"], 1)
+        
+        self.assertIsInstance(metrics["accuracy"], float)
+        self.assertIsInstance(metrics["precision"], float)
+        self.assertIsInstance(metrics["recall"], float)
+        self.assertIsInstance(metrics["f1_score"], float)
+        
+        cm = metrics["confusion_matrix"]
+        self.assertIn("true_positives", cm)
+        self.assertIn("true_negatives", cm)
+        self.assertIn("false_positives", cm)
+        self.assertIn("false_negatives", cm)
+        for key, value in cm.items():
+            self.assertGreaterEqual(int(value), 0)
+
+    @patch('sast_agent_workflow.tools.calculate_metrics.get_human_verified_results')
+    async def test__aiq_tests__perfect_predictions_calculates_correct_metrics(self, mock_get_ground_truth):
+        # preparation
+        mock_ground_truth = {
+            "def1": "no",
+            "def2": "no"
+        }
+        mock_get_ground_truth.return_value = mock_ground_truth
+        
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=True)
+        
+        for per_issue_data in tracker.issues.values():
+            per_issue_data.analysis_response.investigation_result = CVEValidationStatus.TRUE_POSITIVE.value
+            per_issue_data.analysis_response.is_final = "TRUE"
+        
+        # testing
+        result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        metrics = result_tracker.metrics
+        self.assertEqual(metrics["predicted_true_positives_count"], 2)
+        self.assertEqual(metrics["predicted_false_positives_count"], 0)
+        self.assertEqual(metrics["actual_true_positives_count"], 2)
+        self.assertEqual(metrics["actual_false_positives_count"], 0)
+        self.assertEqual(metrics["accuracy"], 1.0)
+
+    @patch('sast_agent_workflow.tools.calculate_metrics.get_human_verified_results')
+    async def test__aiq_tests__calculation_failure_captures_error(self, mock_get_ground_truth):
+        # preparation
+        mock_get_ground_truth.side_effect = Exception("Ground truth loading failed")
+        
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=True)
+        
+        for per_issue_data in tracker.issues.values():
+            per_issue_data.analysis_response.is_final = "TRUE"
+        
+        # testing
+        result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        self.assertIn("error", result_tracker.metrics)
+        self.assertIn("Ground truth loading failed", result_tracker.metrics["error"])
+        self.assertIn("Metrics calculation failed", result_tracker.metrics["error"])
+        self.assertEqual(len(result_tracker.issues), 2)
+        self.assertEqual(tracker.iteration_count, result_tracker.iteration_count)
+
+    async def test__aiq_tests__empty_tracker_returns_error(self):
+        # preparation
+        tracker = SASTWorkflowTracker(issues={})
+        tracker.config = self._create_mock_config(calculate_metrics=True)
+        
+        # testing
+        result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        self.assertEqual(result_tracker.metrics, {"error": "No completed issues found"})
+
+    async def test__aiq_tests__preserves_all_other_data_unchanged(self):
+        # preparation
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=True)
+        
+        import copy
+        original_iteration_count = tracker.iteration_count
+        original_issues = copy.deepcopy(tracker.issues)
+        original_config = tracker.config
+        
+        list(tracker.issues.values())[0].analysis_response.is_final = "TRUE"
+        
+        # testing
+        with patch('sast_agent_workflow.tools.calculate_metrics.get_human_verified_results') as mock_get_ground_truth:
+            mock_get_ground_truth.return_value = None
+            result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+        
+        # assertion
+        self.assertEqual(result_tracker.iteration_count, original_iteration_count)
+        self.assertEqual(len(result_tracker.issues), len(original_issues))
+        self.assertEqual(result_tracker.config, original_config)
+        
+        for issue_id, per_issue_data in result_tracker.issues.items():
             self.assertIsInstance(per_issue_data.issue, Issue)
-            self.assertIsNotNone(per_issue_data.analysis_response)
             self.assertIsInstance(per_issue_data.analysis_response, AnalysisResponse)
+            self.assertIsInstance(per_issue_data.source_code, dict)
+            self.assertEqual(per_issue_data.issue.id, original_issues[issue_id].issue.id)
+
+    async def test__aiq_tests__critique_enabled_uses_correct_config(self):
+        # preparation
+        tracker = TestUtils.create_sample_tracker(self.sample_issues)
+        tracker.config = self._create_mock_config(calculate_metrics=True, use_critique_as_final=True)
         
-        self.assertIsInstance(result_tracker.metrics, dict)
+        issue_ids = list(tracker.issues.keys())
+        per_issue = tracker.issues[issue_ids[0]]
+        per_issue.analysis_response.investigation_result = CVEValidationStatus.TRUE_POSITIVE.value
+        per_issue.analysis_response.is_final = "TRUE"
         
-        # TODO: Add specific assertions for calculate_metrics tool state changes when implemented:
-        # - Verify metrics dictionary is populated with calculated statistics
-        # - Verify metrics only calculated when enabled in config
+        # testing
+        with patch('sast_agent_workflow.tools.calculate_metrics.get_human_verified_results') as mock_get_ground_truth:
+            with patch('sast_agent_workflow.tools.calculate_metrics.EvaluationSummary') as mock_eval_summary:
+                mock_get_ground_truth.return_value = None
+                mock_eval_instance = Mock()
+                mock_eval_instance.predicted_summary = [(issue_ids[0], per_issue.analysis_response, 0)]
+                mock_eval_instance.predicted_true_positives = {issue_ids[0]}
+                mock_eval_instance.predicted_false_positives = set()
+                mock_eval_instance.ground_truth = None
+                mock_eval_summary.return_value = mock_eval_instance
+                
+                result_tracker = await TestUtils.run_single_fn(calculate_metrics, self.calculate_metrics_config, self.builder, tracker)
+                
+                mock_eval_summary.assert_called_once()
+                call_args = mock_eval_summary.call_args
+                passed_config = call_args[0][1]
+                self.assertTrue(passed_config.USE_CRITIQUE_AS_FINAL_RESULTS)
+        
+        # assertion
+        self.assertIn("total_issues", result_tracker.metrics)
+        self.assertIn("has_ground_truth", result_tracker.metrics)
 
 
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()

--- a/tests/integration/test_llm_service_workflow.py
+++ b/tests/integration/test_llm_service_workflow.py
@@ -61,7 +61,7 @@ class TestInvestigateIssue:
         mock_config.JUSTIFICATION_SUMMARY_HUMAN_PROMPT = "Test summary human"
         mock_config.EVALUATION_PROMPT = "Test evaluation prompt"
 
-        test_issue = Issue("test-issue-1")
+        test_issue = Issue(id="test-issue-1")
         test_issue.issue_type = "BUFFER_SIZE"
         test_issue.issue_cve = "CWE-474"
         test_issue.trace = "buffer overflow at line 121"
@@ -106,7 +106,7 @@ class TestInvestigateIssue:
         mock_config.JUSTIFICATION_SUMMARY_HUMAN_PROMPT = "Test summary human"
         mock_config.EVALUATION_PROMPT = "Test evaluation prompt"
 
-        test_issue = Issue("test-issue-1")
+        test_issue = Issue(id="test-issue-1")
         test_issue.issue_type = "BUFFER_SIZE"
         test_issue.issue_cve = "CWE-474"
         test_issue.trace = "buffer overflow at line 121"
@@ -146,7 +146,7 @@ class TestInvestigateIssue:
         mock_config.JUSTIFICATION_SUMMARY_HUMAN_PROMPT = "Test summary human"
         mock_config.EVALUATION_PROMPT = "Test evaluation prompt"
 
-        test_issue = Issue("test-issue-2")
+        test_issue = Issue(id="test-issue-2")
         test_issue.issue_type = "BUFFER_SIZE" 
         test_issue.issue_cve = "CWE-474"
         test_issue.trace = "false positive case"

--- a/tests/unit/dto/test_EvaluationSummary.py
+++ b/tests/unit/dto/test_EvaluationSummary.py
@@ -17,8 +17,8 @@ class TestEvaluationSummary:
         mock_config = Mock()
         mock_config.USE_CRITIQUE_AS_FINAL_RESULTS = False
         
-        issue1 = Issue("issue1")
-        issue2 = Issue("issue2")
+        issue1 = Issue(id="issue1")
+        issue2 = Issue(id="issue2")
         
         response1 = AnalysisResponse("TRUE POSITIVE", "TRUE", "", [], "", [], [], [])
         response2 = AnalysisResponse(" FALSE POSITIVE", "TRUE", "", [], "", [], [], [])
@@ -47,7 +47,7 @@ class TestEvaluationSummary:
         mock_config = Mock()
         mock_config.USE_CRITIQUE_AS_FINAL_RESULTS = False
         
-        issue1 = Issue("issue1")
+        issue1 = Issue(id="issue1")
         response1 = AnalysisResponse("TRUE POSITIVE", "TRUE", "", [], "", [], [], [])
         summary1 = SummaryInfo(response1, {}, "", "")
         

--- a/tests/unit/stage/test_filter_known_issues.py
+++ b/tests/unit/stage/test_filter_known_issues.py
@@ -23,7 +23,7 @@ class TestCaptureKnownIssues:
         mock_llm_service.vector_service = mock_vector_service
         mock_llm_service.embedding_llm = Mock()
         
-        issue1 = Issue("issue1")
+        issue1 = Issue(id="issue1")
         issue_list = [issue1]
         
         # testing
@@ -63,9 +63,9 @@ class TestCaptureKnownIssues:
         mock_llm_service.vector_service = mock_vector_service
         mock_llm_service.embedding_llm = Mock()
         
-        issue1 = Issue("issue1")
-        issue2 = Issue("issue2") 
-        issue3 = Issue("issue3")
+        issue1 = Issue(id="issue1")
+        issue2 = Issue(id="issue2") 
+        issue3 = Issue(id="issue3")
         issue_list = [issue1, issue2, issue3]
         
         def mock_filter_error(issue, context):
@@ -116,9 +116,9 @@ class TestCaptureKnownIssues:
         mock_llm_service.vector_service = mock_vector_service
         mock_llm_service.embedding_llm = Mock()
         
-        issue1 = Issue("issue1")
-        issue2 = Issue("issue2") 
-        issue3 = Issue("issue3")
+        issue1 = Issue(id="issue1")
+        issue2 = Issue(id="issue2") 
+        issue3 = Issue(id="issue3")
         issue_list = [issue1, issue2, issue3]
         
         def mock_filter_error(issue, context):
@@ -162,7 +162,7 @@ class TestCaptureKnownIssues:
         mock_config = Mock()
         mock_config.KNOWN_FALSE_POSITIVE_FILE_PATH = "/nonexistent/path/file.txt"
         
-        issue_list = [Issue("issue1")]
+        issue_list = [Issue(id="issue1")]
         
         # testing
         with patch('src.stage.filter_known_issues.read_known_errors_file', side_effect=FileNotFoundError("File not found")):
@@ -177,7 +177,7 @@ class TestCaptureKnownIssues:
         mock_config.KNOWN_FALSE_POSITIVE_FILE_PATH = "empty_file.txt"
         mock_config.SIMILARITY_ERROR_THRESHOLD = 3
         
-        issue_list = [Issue("issue1")]
+        issue_list = [Issue(id="issue1")]
         
         mock_vector_db = Mock()
         mock_retriever = Mock()


### PR DESCRIPTION
  Implements the Calculate_Metrics node for SAST workflow performance evaluation.

  Features:
  - Calculates ML performance metrics (accuracy, precision, recall, F1-score)
  - Supports both with/without ground truth scenarios
  - Dynamic metric extraction for future extensibility
  - Configuration-driven execution (CALCULATE_METRICS flag)
  - Graceful error handling with workflow continuation

  Implementation:
  - Leverages existing EvaluationSummary class
  - Only processes issues marked as is_final="TRUE"
  - Populates tracker.metrics dictionary with calculated statistics
  - Maintains data immutability (only modifies metrics)

  Testing:
  - 97% code coverage with 11 comprehensive tests
  - Covers all scenarios: config validation, data processing, error handling
  - TDD approach with preparation/testing/assertion structure
