### PR TITLE
fix: pass USE_KNOWN_FALSE_POSITIVE_FILE parameter to 'execute-ai-anal…

### DIFF
--- a/deploy/tekton/pipeline.yaml
+++ b/deploy/tekton/pipeline.yaml
@@ -47,6 +47,10 @@ spec:
       type: string
       description: "Optional GDrive SA file name"
       default: "service_account.json"
+    - name: USE_KNOWN_FALSE_POSITIVE_FILE
+      type: string
+      description: "Whether to use known false positive file for filtering (true/false)"
+      default: "true"
   workspaces:
     - name: shared-workspace
     - name: gitlab-token-ws
@@ -121,6 +125,8 @@ spec:
           value: "$(params.EMBEDDINGS_LLM_MODEL_NAME)"
         - name: AGGREGATE_RESULTS_G_SHEET
           value: "$(params.AGGREGATE_RESULTS_G_SHEET)"
+        - name: USE_KNOWN_FALSE_POSITIVE_FILE
+          value: "$(params.USE_KNOWN_FALSE_POSITIVE_FILE)"
       workspaces:
         - name: source-workspace
           workspace: shared-workspace


### PR DESCRIPTION
pass `USE_KNOWN_FALSE_POSITIVE_FILE` parameter to `execute-ai-analysis` task to get the correct value and not always default to `true`