### PR TITLE
Fix duplicate Config instantiation in investigate node

### DIFF
--- a/src/sast_agent_workflow/nodes/investigate.py
+++ b/src/sast_agent_workflow/nodes/investigate.py
@@ -33,8 +33,9 @@ async def investigate(config: InvestigateConfig, builder: Builder):
     logger.info("Initializing Investigate function...")
 
     llm = await builder.get_llm(config.llm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
-    tools = create_investigation_tools(Config())
-    investigate_node_fn = create_investigate_node(Config(), llm, tools)
+    workflow_config = Config()
+    tools = create_investigation_tools(workflow_config)
+    investigate_node_fn = create_investigate_node(workflow_config, llm, tools)
 
     async def _investigate_fn(tracker: SASTWorkflowTracker) -> SASTWorkflowTracker:
         if tracker is None:


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                       
                                                                                                                                                                                                                                   
  The `investigate` node was instantiating `Config()` twice on consecutive lines (36-37), causing configuration to be printed twice in server logs:                                                                                
                                                                                                                                                                                                                                 
  ```python
  tools = create_investigation_tools(Config())  # ← First instantiation
  investigate_node_fn = create_investigate_node(Config(), llm, tools)  # ← Second instantiation                
  ```                                                                                                                    
                                                                                                                                                                                                                                   
Each Config() call runs:                                                                                                                                                                                                         
- YAML parsing                                                                                                                                                                                                                   
- Environment variable loading                                                                                                                                                                                                 
- Prompt template loading (8 templates)
- Validation                           
- Config printing ← visible symptom in logs                                                                                                                                                                                      
 
Solution                                                                                                                                                                                                                         
                                                                                                                                                                                                                               
Create Config() once and reuse it:                                                                                                                                                                                               
                                                                                                                                                                                                                               
                                                                                                                                                                                                                                 ```python
    workflow_config = Config()
    tools = create_investigation_tools(workflow_config)                                                                                                                                                                              
    investigate_node_fn = create_investigate_node(workflow_config, llm, tools)
```