### PR TITLE
update system package versions to resolve build failure

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -5,16 +5,16 @@ on:
     branches:
       - main
     paths:
-      - '../../Containerfile.base.dockerfile'
+      - 'Containerfile.base.dockerfile'
       - '.github/workflows/build-base-image.yml'
   pull_request:
     branches:
       - main
     paths:
-      - '../../Containerfile.base.dockerfile'
+      - 'Containerfile.base.dockerfile'
       - '.github/workflows/build-base-image.yml'
-    types:
-      - closed
+  schedule:
+    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
   workflow_dispatch:
 
 env:
@@ -24,8 +24,8 @@ env:
 jobs:
   build-base:
     runs-on: ubuntu-latest
-    # Only run on direct pushes to main OR when PRs are merged (not just closed) OR manual trigger
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    # Only run on direct pushes to main OR when PRs are merged (not just closed) OR scheduled OR manual trigger
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -24,8 +24,8 @@ env:
 jobs:
   build-base:
     runs-on: ubuntu-latest
-    # Only run on direct pushes to main OR when PRs are merged (not just closed) OR scheduled OR manual trigger
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    # Run on push to main, PRs (for validation), scheduled builds, or manual trigger
+    # Image is only pushed to registry when event is NOT a pull_request
     permissions:
       contents: read
       packages: write
@@ -38,6 +38,8 @@ jobs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
     - name: Log in to Quay.io
+      # Skip login on PRs - no push means no auth needed, and secrets may be unavailable for forked PRs
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3
       with:
         registry: ${{ env.REGISTRY }}
@@ -64,7 +66,8 @@ jobs:
         context: .
         file: ./Containerfile.base.dockerfile
         platforms: linux/amd64
-        push: true
+        # Only push to registry on: push to main, scheduled runs, or manual trigger (NOT on pull_request)
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
@@ -78,8 +81,17 @@ jobs:
         echo "**Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
         echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Container Images Published:**" >> $GITHUB_STEP_SUMMARY
-        echo "- \`${{ env.IMAGE_NAME }}:latest\`" >> $GITHUB_STEP_SUMMARY
-        echo "- \`${{ env.IMAGE_NAME }}:main-${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Registry:** [Quay.io Repository](https://quay.io/repository/ecosystem-appeng/sast-ai-base-image)" >> $GITHUB_STEP_SUMMARY
+
+        # Different summary for PRs (validation only) vs pushes (published images)
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "**Build Status:** ✅ Validation successful (no image push)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "This PR validates that the Containerfile builds correctly." >> $GITHUB_STEP_SUMMARY
+          echo "Images will be published to registry after merge to main." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "**Container Images Published:**" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.IMAGE_NAME }}:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.IMAGE_NAME }}:main-${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Registry:** [Quay.io Repository](https://quay.io/repository/ecosystem-appeng/sast-ai-base-image)" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/Containerfile.base.dockerfile
+++ b/Containerfile.base.dockerfile
@@ -28,12 +28,12 @@ USER 0
 #
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     dnf install -y --allowerasing \
-        git-2.47.3-1.el9_6 \
-        rpm-build-4.16.1.3-39.el9 \
-        curl-7.76.1-34.el9 \
-        jq-1.6-19.el9 \
-        file-5.39-16.el9 \
-        csdiff-3.5.5-1.el9 && \
+        git-2.52.0-1.el9 \
+        rpm-build-4.16.1.3-40.el9 \
+        curl-7.76.1-40.el9 \
+        jq-1.6-19.el9_8.2 \
+        file-5.39-17.el9 \
+        csdiff-3.5.7-1.el9 && \
     dnf clean all && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir \


### PR DESCRIPTION
## Problem   
Base image build failing - pinned packages removed from EPEL 9/UBI 9 repos.

   ## Solution

   **Updated package versions:**
   - \`csdiff\`: 3.5.5-1.el9 → 3.5.7-1.el9 (fixes build, preserves \`csgrep --mode sarif\`)
   - \`git\`, \`curl\`, \`jq\`, \`rpm-build\`, \`file\`: updated to latest available

   **Workflow improvements:**
   - Fixed path filter: \`../../Containerfile.base.dockerfile\` → \`Containerfile.base.dockerfile\`
   - Added weekly scheduled builds (Sundays 2 AM UTC) to catch package drift
   - Enabled PR validation: builds on PRs without pushing to registry
   - Skip Quay login on PRs (no secrets needed for validation)
