### PR TITLE
Generate sast-ai-gdrive-config ConfigMap from GDRIVE_FOLDER_ID in .env during deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ deploy/tekton/eventlistener/benchmark-config.yaml
 
 # Generated secrets and service accounts (created by prepare-kustomize.sh)
 deploy/tekton/overlays/*/secrets-*.env
+deploy/tekton/overlays/*/configmap-*.env
 deploy/tekton/overlays/*/service-accounts/
 gcs_service_account.json
 service_account.json

--- a/deploy/scripts/prepare-kustomize.sh
+++ b/deploy/scripts/prepare-kustomize.sh
@@ -191,6 +191,19 @@ EOF
     fi
 fi
 
+# Google Drive folder ID ConfigMap (optional)
+if [[ -n "${GDRIVE_FOLDER_ID}" ]]; then
+    cat > "${OVERLAY_DIR}/configmap-gdrive.env" <<EOF
+folder-id=${GDRIVE_FOLDER_ID}
+EOF
+    echo "   ✓ configmap-gdrive.env created (Google Drive folder ID configured)"
+else
+    cat > "${OVERLAY_DIR}/configmap-gdrive.env" <<EOF
+folder-id=
+EOF
+    echo "   ⚠️  GDRIVE_FOLDER_ID not configured (optional - can be passed at runtime via make run)"
+fi
+
 # Konflux Trusted Artifacts registry token (optional)
 if [[ -n "${KONFLUX_TOKEN}" ]]; then
     cat > "${OVERLAY_DIR}/secrets-konflux.env" <<EOF

--- a/deploy/tekton/overlays/dev/kustomization.yaml
+++ b/deploy/tekton/overlays/dev/kustomization.yaml
@@ -57,3 +57,11 @@ secretGenerator:
       - secrets-konflux.env
     options:
       disableNameSuffixHash: true
+
+configMapGenerator:
+  # Google Drive folder ID (optional - used to upload generated file to given gdrive folder)
+  - name: sast-ai-gdrive-config
+    envs:
+      - configmap-gdrive.env
+    options:
+      disableNameSuffixHash: true

--- a/deploy/tekton/overlays/mlops/kustomization.yaml
+++ b/deploy/tekton/overlays/mlops/kustomization.yaml
@@ -58,6 +58,14 @@ secretGenerator:
     options:
       disableNameSuffixHash: true
 
+configMapGenerator:
+  # Google Drive folder ID (optional - used to upload generated file to given gdrive folder)
+  - name: sast-ai-gdrive-config
+    envs:
+      - configmap-gdrive.env
+    options:
+      disableNameSuffixHash: true
+
 patches:
   # Task patches
   - target:

--- a/deploy/tekton/overlays/prod/kustomization.yaml
+++ b/deploy/tekton/overlays/prod/kustomization.yaml
@@ -58,6 +58,14 @@ secretGenerator:
     options:
       disableNameSuffixHash: true
 
+configMapGenerator:
+  # Google Drive folder ID (optional - used to upload generated file to given gdrive folder)
+  - name: sast-ai-gdrive-config
+    envs:
+      - configmap-gdrive.env
+    options:
+      disableNameSuffixHash: true
+
 patches:
   # Task patches - using JSON Patch to override specific parameter defaults
   - target:


### PR DESCRIPTION
The Tekton upload step already supports reading `GDRIVE_FOLDER_ID` from a **sast-ai-gdrive-config** ConfigMap as a fallback, but the ConfigMap was never created during deployment. This meant users had to pass GDRIVE_FOLDER_ID explicitly on every make run invocation.

This PR wires up the existing fallback by generating the ConfigMap from .env at deploy time via prepare-kustomize.sh and Kustomize's configMapGenerator, so the folder ID is baked into the deployment once and doesn't need to be repeated on each pipeline run.